### PR TITLE
Setting explicit dimensions to fix for Android.

### DIFF
--- a/AppIntro.js
+++ b/AppIntro.js
@@ -355,6 +355,8 @@ class AppIntro extends Component {
             index={this.props.defaultIndex}
             renderPagination={this.renderPagination}
             scrollEnabled={this.props.scrollEnabled}
+            width={windowsWidth}
+            height={windowsHeight}
             onMomentumScrollEnd={(e, state) => {
               if (this.isToTintStatusBar()) {
                 StatusBar.setBackgroundColor(this.shadeStatusBarColor(this.props.pageArray[state.index].backgroundColor, -0.3), false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-falcon-app-intro",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "rn-falcon-app-intro is a react native plugin implementing a parallax effect welcome page using base on react-native-swiper , similar to the one found in Google's app like Sheet, Drive, Docs...",
   "main": "AppIntro.js",
   "scripts": {


### PR DESCRIPTION
My swiper view wasn't rendering on Android until explicitly setting dimensions. In my app it makes sense to always maximize these, but if that's not always the case perhaps we should have an optional parameter to be passed through?