### PR TITLE
Fix: Done button does not feel button-like

### DIFF
--- a/components/DoneButton.ios.js
+++ b/components/DoneButton.ios.js
@@ -24,25 +24,28 @@ export const DoneButton = ({
         }],
       }]}
       >
-        <View style={styles.full}>
+        <TouchableOpacity
+          style={styles.full}
+          onPress={isDoneBtnShow ? onDoneBtnClick : onNextBtnClick}
+        >
           <Text style={[styles.controllText, {
             color: rightTextColor, paddingRight: 30,
           }]}>
             {doneBtnLabel}
           </Text>
-        </View>
-      </Animated.View>
-      <Animated.View style={[styles.full, { height: 0 }, { opacity: nextOpacity }]}>
-        <TouchableOpacity style={styles.full}
-          onPress={ isDoneBtnShow ? onDoneBtnClick : onNextBtnClick}>
-         <Text style={[styles.nextButtonText, { color: rightTextColor }]}>
-          {nextBtnLabel}
-        </Text>
         </TouchableOpacity>
       </Animated.View>
+      {isDoneBtnShow ? null : (
+        <Animated.View style={[styles.full, { height: 0 }, { opacity: nextOpacity }]}>
+          <TouchableOpacity style={styles.full} onPress={onNextBtnClick}>
+            <Text style={[styles.nextButtonText, { color: rightTextColor }]}>
+              {nextBtnLabel}
+            </Text>
+          </TouchableOpacity>
+        </Animated.View>
+      )}
     </View>
   )
 }
 
 export default DoneButton
-        


### PR DESCRIPTION
On iOS (didn't check Android so far) the DONE button was just a `View` element and thus didn't show any button feel which the `TouchableOpacity` element offers.

I made that change and had to additionally remove the next button when the done button is shown so that it's not situated above the done button and thus the touch-effect is missing.